### PR TITLE
Extract constants to dedicated file

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,25 @@
+export const VIEW_TYPE_DASHBOARD = 'tasklens-dashboard-view';
+export const VIEW_TYPE_TIMELINE = 'tasklens-timeline-view';
+export const VIEW_TYPE_LIST = 'tasklens-list-view';
+export const VIEW_TYPE_STATS = 'tasklens-stats-view';
+
+export const ICON_NAME = 'tasklens-icon';
+export const ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="11" cy="11" r="8"></circle>
+  <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+  <path d="M8 11.5L10 13.5L14 8.5"></path>
+</svg>`;
+
+export const CLASS_HIDE_TABS = 'tasklens-hide-tabs';
+export const CLASS_CHROMELESS = 'tasklens-chromeless';
+export const CLASS_DASHBOARD_VIEW = 'tasklens-dashboard-view';
+export const CLASS_SETTINGS = 'tasklens-settings';
+export const CLASS_WELCOME_MODAL = 'tasklens-welcome-modal';
+export const CLASS_FEATURE_HIGHLIGHT = 'feature-highlight';
+
+export const ALL_VIEW_TYPES = [
+    VIEW_TYPE_DASHBOARD,
+    VIEW_TYPE_TIMELINE,
+    VIEW_TYPE_LIST,
+    VIEW_TYPE_STATS
+];

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,11 +3,22 @@ import { TaskManager } from './services/TaskManager';
 import { TaskParser } from './services/TaskParser';
 import { SemesterSettings, DEFAULT_SETTINGS } from './settings/Settings';
 import { SettingsTab } from './settings/SettingsTab';
-import { DashboardView, VIEW_TYPE_DASHBOARD } from './views/DashboardView';
-import { TimelineView, VIEW_TYPE_TIMELINE } from './views/TimelineView';
-import { TaskListView, VIEW_TYPE_LIST } from './views/TaskListView';
-import { StatsView, VIEW_TYPE_STATS } from './views/StatsView';
+import { DashboardView } from './views/DashboardView';
+import { TimelineView } from './views/TimelineView';
+import { TaskListView } from './views/TaskListView';
+import { StatsView } from './views/StatsView';
 import { QuickAddModal } from './modals/QuickAddModal';
+import {
+    VIEW_TYPE_DASHBOARD,
+    VIEW_TYPE_TIMELINE,
+    VIEW_TYPE_LIST,
+    VIEW_TYPE_STATS,
+    ICON_NAME,
+    ICON_SVG,
+    ALL_VIEW_TYPES,
+    CLASS_HIDE_TABS,
+    CLASS_FEATURE_HIGHLIGHT
+} from './constants';
 import { WelcomeModal } from './modals/WelcomeModal';
 
 export interface RefreshableView {
@@ -16,14 +27,6 @@ export interface RefreshableView {
     applyColorTheme?(): void;
 }
 
-// All view types in one place — used repeatedly for bulk operations
-const ALL_VIEW_TYPES = [VIEW_TYPE_DASHBOARD, VIEW_TYPE_TIMELINE, VIEW_TYPE_LIST, VIEW_TYPE_STATS];
-
-const TASKLENS_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <circle cx="11" cy="11" r="8"></circle>
-  <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-  <path d="M8 11.5L10 13.5L14 8.5"></path>
-</svg>`;
 
 // Obsidian doesn't expose split types on WorkspaceRoot, so we cast where needed
 type WorkspaceWithSplits = {
@@ -67,7 +70,7 @@ export default class TaskLensPlugin extends Plugin {
         this.registerView(VIEW_TYPE_LIST, (leaf) => new TaskListView(leaf, this));
         this.registerView(VIEW_TYPE_STATS, (leaf) => new StatsView(leaf, this));
 
-        addIcon('tasklens-icon', TASKLENS_ICON);
+        addIcon(ICON_NAME, ICON_SVG);
         this.setupRibbonIcon();
         this.setupCommands();
 
@@ -87,8 +90,8 @@ export default class TaskLensPlugin extends Plugin {
     }
 
     private setupRibbonIcon(): void {
-        const ribbonIconEl = this.addRibbonIcon('tasklens-icon', 'Tasklens', (evt: MouseEvent) => {
-            ribbonIconEl.removeClass('feature-highlight');
+        const ribbonIconEl = this.addRibbonIcon(ICON_NAME, 'Tasklens', (evt: MouseEvent) => {
+            ribbonIconEl.removeClass(CLASS_FEATURE_HIGHLIGHT);
 
             if (!this.settings.hasClickedRibbonIcon) {
                 this.settings.hasClickedRibbonIcon = true;
@@ -130,7 +133,7 @@ export default class TaskLensPlugin extends Plugin {
 
         // Highlight the ribbon icon until the user has seen the welcome screen and clicked it
         if (!this.settings.hasSeenWelcome || !this.settings.hasClickedRibbonIcon) {
-            ribbonIconEl.addClass('feature-highlight');
+            ribbonIconEl.addClass(CLASS_FEATURE_HIGHLIGHT);
         }
     }
 
@@ -167,7 +170,7 @@ export default class TaskLensPlugin extends Plugin {
             this.app.workspace.getLeavesOfType(type).forEach(leaf => {
                 const tabContainer = leaf.view.containerEl.closest('.workspace-tabs');
                 if (tabContainer) {
-                    tabContainer.classList.toggle('tasklens-hide-tabs', this.isLayoutLocked);
+                    tabContainer.classList.toggle(CLASS_HIDE_TABS, this.isLayoutLocked);
                 }
             });
         });
@@ -232,7 +235,7 @@ export default class TaskLensPlugin extends Plugin {
         } else {
             const tabContainer = leaf.view.containerEl.closest('.workspace-tabs');
             if (tabContainer instanceof HTMLElement) {
-                tabContainer.classList.remove('tasklens-hide-tabs');
+                tabContainer.classList.remove(CLASS_HIDE_TABS);
             }
         }
     }
@@ -262,5 +265,3 @@ export default class TaskLensPlugin extends Plugin {
         });
     }
 }
-
-/* #TODO constants file*/

--- a/src/modals/WelcomeModal.ts
+++ b/src/modals/WelcomeModal.ts
@@ -1,5 +1,6 @@
 import { App, Modal, Setting } from 'obsidian';
 import TaskLensPlugin from '../main';
+import { CLASS_WELCOME_MODAL } from '../constants';
 
 export class WelcomeModal extends Modal {
     constructor(app: App, private plugin: TaskLensPlugin) {
@@ -9,7 +10,7 @@ export class WelcomeModal extends Modal {
     onOpen() {
         const { contentEl } = this;
         contentEl.empty();
-        contentEl.addClass('tasklens-welcome-modal');
+        contentEl.addClass(CLASS_WELCOME_MODAL);
 
         const header = contentEl.createDiv('welcome-header');
         header.setCssProps({ 'text-align': 'center', 'margin-bottom': '20px' });

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -2,6 +2,7 @@ import { App, PluginSettingTab, Setting } from 'obsidian';
 import TaskLensPlugin from '../main';
 import { WelcomeModal } from '../modals/WelcomeModal';
 import { getTopicColor } from './Settings';
+import { CLASS_SETTINGS } from '../constants';
 
 export class SettingsTab extends PluginSettingTab {
     readonly plugin: TaskLensPlugin;
@@ -14,7 +15,7 @@ export class SettingsTab extends PluginSettingTab {
     display(): void {
         const { containerEl } = this;
         containerEl.empty();
-        containerEl.addClass('tasklens-settings');
+        containerEl.addClass(CLASS_SETTINGS);
 
         // --- NATIVE HEADER WITH HELP BUTTON ---
         new Setting(containerEl)

--- a/src/views/DashboardView.ts
+++ b/src/views/DashboardView.ts
@@ -6,8 +6,8 @@ import { TimelineComponent } from './TimelineComponent';
 import { TaskListComponent } from './TaskListComponent';
 import { HeaderComponent, HeaderState } from './HeaderComponent';
 import { QuickAddModal } from '../modals/QuickAddModal';
+import { VIEW_TYPE_DASHBOARD, CLASS_CHROMELESS, CLASS_HIDE_TABS, CLASS_DASHBOARD_VIEW } from '../constants';
 
-export const VIEW_TYPE_DASHBOARD = 'tasklens-dashboard-view';
 
 // Applies chromeless styling to the leaf and optionally hides tabs when the layout is locked
 export function setupViewDOM(
@@ -20,16 +20,16 @@ export function setupViewDOM(
     const leafRootEl = leafRootRaw instanceof HTMLElement ? leafRootRaw : null;
     const tabContainer = tabContainerRaw instanceof HTMLElement ? tabContainerRaw : null;
 
-    if (leafRootEl) leafRootEl.classList.add('tasklens-chromeless');
-    if (tabContainer && isLocked) tabContainer.classList.add('tasklens-hide-tabs');
+    if (leafRootEl) leafRootEl.classList.add(CLASS_CHROMELESS);
+    if (tabContainer && isLocked) tabContainer.classList.add(CLASS_HIDE_TABS);
 
     return { leafRootEl, tabContainer };
 }
 
 // Reverses the DOM changes made by setupViewDOM on close
 export function cleanUpViewDOM(leafRootEl: HTMLElement | null, tabContainer: HTMLElement | null): void {
-    if (tabContainer instanceof HTMLElement) tabContainer.classList.remove('tasklens-hide-tabs');
-    if (leafRootEl instanceof HTMLElement) leafRootEl.classList.remove('tasklens-chromeless');
+    if (tabContainer instanceof HTMLElement) tabContainer.classList.remove(CLASS_HIDE_TABS);
+    if (leafRootEl instanceof HTMLElement) leafRootEl.classList.remove(CLASS_CHROMELESS);
 }
 
 export class DashboardView extends ItemView implements RefreshableView {
@@ -164,7 +164,7 @@ export class DashboardView extends ItemView implements RefreshableView {
         this.tabContainer = tabContainer;
 
         this.contentEl.empty();
-        this.contentEl.addClass('tasklens-dashboard-view');
+        this.contentEl.addClass(CLASS_DASHBOARD_VIEW);
         this.applyColorTheme();
 
         void this.taskManager.loadTasks().then(() => {

--- a/src/views/HeaderComponent.ts
+++ b/src/views/HeaderComponent.ts
@@ -1,4 +1,5 @@
 import { setIcon } from 'obsidian';
+import { CLASS_FEATURE_HIGHLIGHT } from '../constants';
 
 export interface HeaderState {
     title: string | null;
@@ -97,13 +98,13 @@ export class HeaderComponent {
 
         if (this.onAdd) {
             const addBtn = rightGroup.createEl('button', { cls: 'header-icon-btn' });
-            if (this.highlightAddButton) addBtn.addClass('feature-highlight');
+            if (this.highlightAddButton) addBtn.addClass(CLASS_FEATURE_HIGHLIGHT);
             setIcon(addBtn, 'plus');
             addBtn.setAttribute('aria-label', 'Quick add task');
             addBtn.addEventListener('click', () => {
                 if (this.highlightAddButton) {
                     this.highlightAddButton = false;
-                    addBtn.removeClass('feature-highlight');
+                    addBtn.removeClass(CLASS_FEATURE_HIGHLIGHT);
                     if (this.onHighlightDismiss) this.onHighlightDismiss();
                 }
                 this.onAdd?.();

--- a/src/views/StatsView.ts
+++ b/src/views/StatsView.ts
@@ -3,8 +3,8 @@ import TaskLensPlugin from '../main';
 import { StatsComponent } from './StatsComponent';
 import { HeaderComponent, HeaderState } from './HeaderComponent';
 import { setupViewDOM, cleanUpViewDOM } from './DashboardView';
+import { VIEW_TYPE_STATS, CLASS_DASHBOARD_VIEW } from '../constants';
 
-export const VIEW_TYPE_STATS = 'tasklens-stats-view';
 
 export class StatsView extends ItemView {
     private leafRootEl: Element | null = null;
@@ -44,7 +44,7 @@ export class StatsView extends ItemView {
         this.tabContainer = tabContainer;
 
         this.contentEl.empty();
-        this.contentEl.addClass('tasklens-dashboard-view');
+        this.contentEl.addClass(CLASS_DASHBOARD_VIEW);
         this.render();
 
         return Promise.resolve();

--- a/src/views/TaskListView.ts
+++ b/src/views/TaskListView.ts
@@ -5,8 +5,8 @@ import { Task } from '../models/Task';
 import { HeaderComponent, HeaderState } from './HeaderComponent';
 import { setupViewDOM, cleanUpViewDOM } from './DashboardView';
 import { QuickAddModal } from '../modals/QuickAddModal';
+import { VIEW_TYPE_LIST, CLASS_DASHBOARD_VIEW } from '../constants';
 
-export const VIEW_TYPE_LIST = 'tasklens-list-view';
 
 export class TaskListView extends ItemView {
     private leafRootEl: HTMLElement | null = null;
@@ -51,7 +51,7 @@ export class TaskListView extends ItemView {
         this.tabContainer = tabContainer;
 
         this.contentEl.empty();
-        this.contentEl.addClass('tasklens-dashboard-view');
+        this.contentEl.addClass(CLASS_DASHBOARD_VIEW);
         this.contentEl.addClass('is-single-view');
         this.isOpen = true;
         this.render();

--- a/src/views/TimelineView.ts
+++ b/src/views/TimelineView.ts
@@ -3,8 +3,8 @@ import TaskLensPlugin, { RefreshableView } from '../main';
 import { TimelineComponent } from './TimelineComponent';
 import { HeaderComponent, HeaderState } from './HeaderComponent';
 import { setupViewDOM, cleanUpViewDOM } from './DashboardView';
+import { VIEW_TYPE_TIMELINE, CLASS_DASHBOARD_VIEW } from '../constants';
 
-export const VIEW_TYPE_TIMELINE = 'tasklens-timeline-view';
 
 export class TimelineView extends ItemView implements RefreshableView {
     private leafRootEl: HTMLElement | null = null;
@@ -76,7 +76,7 @@ export class TimelineView extends ItemView implements RefreshableView {
         this.tabContainer = tabContainer;
 
         this.contentEl.empty();
-        this.contentEl.addClass('tasklens-dashboard-view');
+        this.contentEl.addClass(CLASS_DASHBOARD_VIEW);
 
         void this.plugin.taskManager.loadTasks().then(() => {
             this.render();


### PR DESCRIPTION
Extracted magic strings and constants from `src/main.ts` and various view and modal files into a new central `src/constants.ts` file. This refactoring improves maintainability and ensures consistency across the plugin by centralizing view identifiers, CSS class names, and icon definitions. Updated all references and imports to use the new constants.

---
*PR created automatically by Jules for task [4956307582158180884](https://jules.google.com/task/4956307582158180884) started by @nightaqua*