### PR TITLE
🧪 [Add tests for hasRecurrenceMetadata]

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-    "version": "node version-bump.mjs && git add manifest.json versions.json"
+    "version": "node version-bump.mjs && git add manifest.json versions.json",
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "Selim",
@@ -22,6 +23,7 @@
     "obsidian": "^1.7.2",
     "tslib": "2.4.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.56.1"
+    "typescript-eslint": "^8.56.1",
+    "vitest": "^4.1.0"
   }
 }

--- a/src/services/__tests__/TaskSanitizer.test.ts
+++ b/src/services/__tests__/TaskSanitizer.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { hasRecurrenceMetadata } from '../TaskSanitizer';
+
+describe('TaskSanitizer', () => {
+    describe('hasRecurrenceMetadata', () => {
+        it('should return true if line contains Tasks plugin repeat emoji 🔁', () => {
+            expect(hasRecurrenceMetadata('- [ ] Every day 🔁 every day')).toBe(true);
+            expect(hasRecurrenceMetadata('- [ ] 🔁')).toBe(true);
+        });
+
+        it('should return true if line contains Tasks plugin finish emoji 🏁', () => {
+            expect(hasRecurrenceMetadata('- [ ] Finish line 🏁')).toBe(true);
+            expect(hasRecurrenceMetadata('🏁 some text')).toBe(true);
+        });
+
+        it('should return true if line contains Dataview/TaskLens repeat inline field [repeat:: ...]', () => {
+            expect(hasRecurrenceMetadata('- [ ] My task [repeat:: daily]')).toBe(true);
+            expect(hasRecurrenceMetadata('- [ ] My task (repeat:: weekly)')).toBe(true);
+            expect(hasRecurrenceMetadata('repeat::')).toBe(true);
+            expect(hasRecurrenceMetadata('Repeat::')).toBe(true);
+            expect(hasRecurrenceMetadata('REPEAT::')).toBe(true);
+        });
+
+        it('should return false if line does not contain recurrence metadata', () => {
+            expect(hasRecurrenceMetadata('- [ ] Normal task without repeat')).toBe(false);
+            expect(hasRecurrenceMetadata('- [ ] Task with completion ✅ 2024-05-15')).toBe(false);
+            expect(hasRecurrenceMetadata('- [ ] Task with due date due:: 2024-05-15')).toBe(false);
+            expect(hasRecurrenceMetadata('No metadata here')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `hasRecurrenceMetadata` function in `src/services/TaskSanitizer.ts` was missing tests. As a pure string-matching function, it is critical that it accurately identifies recurrence markers to prevent double-stamping when tasks are cloned.

📊 **Coverage:** What scenarios are now tested
The new tests cover:
- Tasks plugin repeat emojis (🔁 `\u{1F501}`) and finish emojis (🏁 `\u{1F3C1}`).
- Dataview/TaskLens repeat inline fields (`[repeat:: ...]`, `(repeat:: ...)`), including case-insensitivity (`REPEAT::`).
- Negative cases: Normal tasks without recurrence metadata, tasks with completion metadata only, and plain text.

✨ **Result:** The improvement in test coverage
The project now has an initial test suite using Vitest (`npm run test`), providing a foundation for future testing. The `hasRecurrenceMetadata` function is now fully covered, ensuring its reliability for recurrence marker detection.

---
*PR created automatically by Jules for task [2571065780618360963](https://jules.google.com/task/2571065780618360963) started by @nightaqua*