### PR TITLE
🧪 test: add tests for formatDisplayDate

### DIFF
--- a/__mocks__/obsidian.ts
+++ b/__mocks__/obsidian.ts
@@ -1,0 +1,3 @@
+export class App {}
+export class TFile {}
+export class Events {}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import obsidianmd from "eslint-plugin-obsidianmd";
 
 export default defineConfig([
     {
-        ignores: ["main.js", "*.mjs", "node_modules/**", "**/*.json"]
+        ignores: ["main.js", "*.mjs", "node_modules/**", "**/*.json", "__mocks__/**", "vitest.config.ts"]
     },
 
     ...obsidianmd.configs.recommended,

--- a/main.js
+++ b/main.js
@@ -518,13 +518,10 @@ var TaskParser = class {
    * RENAMED: Matches TaskManager.loadTasks()
    */
   async findAllTasks() {
-    const tasks = [];
     const filesToScan = this.getFilesToScan();
-    for (const file of filesToScan) {
-      const fileTasks = await this.parseTasksFromFile(file);
-      tasks.push(...fileTasks);
-    }
-    return tasks;
+    const taskPromises = filesToScan.map((file) => this.parseTasksFromFile(file));
+    const allFileTasks = await Promise.all(taskPromises);
+    return allFileTasks.flat();
   }
   /**
    * RENAMED: Matches TaskManager.refreshFileTask()
@@ -706,6 +703,32 @@ var import_obsidian4 = require("obsidian");
 
 // src/modals/WelcomeModal.ts
 var import_obsidian3 = require("obsidian");
+
+// src/constants.ts
+var VIEW_TYPE_DASHBOARD = "tasklens-dashboard-view";
+var VIEW_TYPE_TIMELINE = "tasklens-timeline-view";
+var VIEW_TYPE_LIST = "tasklens-list-view";
+var VIEW_TYPE_STATS = "tasklens-stats-view";
+var ICON_NAME = "tasklens-icon";
+var ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="11" cy="11" r="8"></circle>
+  <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+  <path d="M8 11.5L10 13.5L14 8.5"></path>
+</svg>`;
+var CLASS_HIDE_TABS = "tasklens-hide-tabs";
+var CLASS_CHROMELESS = "tasklens-chromeless";
+var CLASS_DASHBOARD_VIEW = "tasklens-dashboard-view";
+var CLASS_SETTINGS = "tasklens-settings";
+var CLASS_WELCOME_MODAL = "tasklens-welcome-modal";
+var CLASS_FEATURE_HIGHLIGHT = "feature-highlight";
+var ALL_VIEW_TYPES = [
+  VIEW_TYPE_DASHBOARD,
+  VIEW_TYPE_TIMELINE,
+  VIEW_TYPE_LIST,
+  VIEW_TYPE_STATS
+];
+
+// src/modals/WelcomeModal.ts
 var WelcomeModal = class extends import_obsidian3.Modal {
   constructor(app, plugin) {
     super(app);
@@ -714,7 +737,7 @@ var WelcomeModal = class extends import_obsidian3.Modal {
   onOpen() {
     const { contentEl } = this;
     contentEl.empty();
-    contentEl.addClass("tasklens-welcome-modal");
+    contentEl.addClass(CLASS_WELCOME_MODAL);
     const header = contentEl.createDiv("welcome-header");
     header.setCssProps({ "text-align": "center", "margin-bottom": "20px" });
     header.createEl("h1", { text: "Welcome to tasklens \u{1F680}" });
@@ -767,7 +790,7 @@ var SettingsTab = class extends import_obsidian4.PluginSettingTab {
   display() {
     const { containerEl } = this;
     containerEl.empty();
-    containerEl.addClass("tasklens-settings");
+    containerEl.addClass(CLASS_SETTINGS);
     new import_obsidian4.Setting(containerEl).setName("Configuration").setHeading().addExtraButton(
       (btn) => btn.setIcon("help-circle").setTooltip("Show tutorial").onClick(() => {
         new WelcomeModal(this.app, this.plugin).open();
@@ -1494,14 +1517,14 @@ var HeaderComponent = class {
     const rightGroup = this.headerEl.createDiv("header-actions-right");
     if (this.onAdd) {
       const addBtn = rightGroup.createEl("button", { cls: "header-icon-btn" });
-      if (this.highlightAddButton) addBtn.addClass("feature-highlight");
+      if (this.highlightAddButton) addBtn.addClass(CLASS_FEATURE_HIGHLIGHT);
       (0, import_obsidian7.setIcon)(addBtn, "plus");
       addBtn.setAttribute("aria-label", "Quick add task");
       addBtn.addEventListener("click", () => {
         var _a;
         if (this.highlightAddButton) {
           this.highlightAddButton = false;
-          addBtn.removeClass("feature-highlight");
+          addBtn.removeClass(CLASS_FEATURE_HIGHLIGHT);
           if (this.onHighlightDismiss) this.onHighlightDismiss();
         }
         (_a = this.onAdd) == null ? void 0 : _a.call(this);
@@ -1681,19 +1704,18 @@ var QuickAddModal = class extends import_obsidian8.Modal {
 };
 
 // src/views/DashboardView.ts
-var VIEW_TYPE_DASHBOARD = "tasklens-dashboard-view";
 function setupViewDOM(containerEl, isLocked) {
   const leafRootRaw = containerEl.closest(".workspace-leaf-content");
   const tabContainerRaw = containerEl.closest(".workspace-tabs");
   const leafRootEl = leafRootRaw instanceof HTMLElement ? leafRootRaw : null;
   const tabContainer = tabContainerRaw instanceof HTMLElement ? tabContainerRaw : null;
-  if (leafRootEl) leafRootEl.classList.add("tasklens-chromeless");
-  if (tabContainer && isLocked) tabContainer.classList.add("tasklens-hide-tabs");
+  if (leafRootEl) leafRootEl.classList.add(CLASS_CHROMELESS);
+  if (tabContainer && isLocked) tabContainer.classList.add(CLASS_HIDE_TABS);
   return { leafRootEl, tabContainer };
 }
 function cleanUpViewDOM(leafRootEl, tabContainer) {
-  if (tabContainer instanceof HTMLElement) tabContainer.classList.remove("tasklens-hide-tabs");
-  if (leafRootEl instanceof HTMLElement) leafRootEl.classList.remove("tasklens-chromeless");
+  if (tabContainer instanceof HTMLElement) tabContainer.classList.remove(CLASS_HIDE_TABS);
+  if (leafRootEl instanceof HTMLElement) leafRootEl.classList.remove(CLASS_CHROMELESS);
 }
 var DashboardView = class extends import_obsidian9.ItemView {
   constructor(leaf, plugin) {
@@ -1801,7 +1823,7 @@ var DashboardView = class extends import_obsidian9.ItemView {
     this.leafRootEl = leafRootEl;
     this.tabContainer = tabContainer;
     this.contentEl.empty();
-    this.contentEl.addClass("tasklens-dashboard-view");
+    this.contentEl.addClass(CLASS_DASHBOARD_VIEW);
     this.applyColorTheme();
     void this.taskManager.loadTasks().then(() => {
       this.render();
@@ -2042,7 +2064,6 @@ var DashboardView = class extends import_obsidian9.ItemView {
 
 // src/views/TimelineView.ts
 var import_obsidian10 = require("obsidian");
-var VIEW_TYPE_TIMELINE = "tasklens-timeline-view";
 var TimelineView = class extends import_obsidian10.ItemView {
   constructor(leaf, plugin) {
     super(leaf);
@@ -2112,7 +2133,7 @@ var TimelineView = class extends import_obsidian10.ItemView {
     this.leafRootEl = leafRootEl;
     this.tabContainer = tabContainer;
     this.contentEl.empty();
-    this.contentEl.addClass("tasklens-dashboard-view");
+    this.contentEl.addClass(CLASS_DASHBOARD_VIEW);
     void this.plugin.taskManager.loadTasks().then(() => {
       this.render();
       const rendered = this.timelineComponent;
@@ -2187,7 +2208,6 @@ var TimelineView = class extends import_obsidian10.ItemView {
 
 // src/views/TaskListView.ts
 var import_obsidian11 = require("obsidian");
-var VIEW_TYPE_LIST = "tasklens-list-view";
 var TaskListView = class extends import_obsidian11.ItemView {
   constructor(leaf, plugin) {
     super(leaf);
@@ -2231,7 +2251,7 @@ var TaskListView = class extends import_obsidian11.ItemView {
     this.leafRootEl = leafRootEl;
     this.tabContainer = tabContainer;
     this.contentEl.empty();
-    this.contentEl.addClass("tasklens-dashboard-view");
+    this.contentEl.addClass(CLASS_DASHBOARD_VIEW);
     this.contentEl.addClass("is-single-view");
     this.isOpen = true;
     this.render();
@@ -2320,7 +2340,6 @@ var StatsComponent = class {
 };
 
 // src/views/StatsView.ts
-var VIEW_TYPE_STATS = "tasklens-stats-view";
 var StatsView = class extends import_obsidian12.ItemView {
   constructor(leaf, plugin) {
     super(leaf);
@@ -2362,7 +2381,7 @@ var StatsView = class extends import_obsidian12.ItemView {
     this.leafRootEl = leafRootEl;
     this.tabContainer = tabContainer;
     this.contentEl.empty();
-    this.contentEl.addClass("tasklens-dashboard-view");
+    this.contentEl.addClass(CLASS_DASHBOARD_VIEW);
     this.render();
     return Promise.resolve();
   }
@@ -2399,12 +2418,6 @@ var StatsView = class extends import_obsidian12.ItemView {
 };
 
 // src/main.ts
-var ALL_VIEW_TYPES = [VIEW_TYPE_DASHBOARD, VIEW_TYPE_TIMELINE, VIEW_TYPE_LIST, VIEW_TYPE_STATS];
-var TASKLENS_ICON = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <circle cx="11" cy="11" r="8"></circle>
-  <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
-  <path d="M8 11.5L10 13.5L14 8.5"></path>
-</svg>`;
 var TaskLensPlugin = class extends import_obsidian13.Plugin {
   constructor() {
     super(...arguments);
@@ -2432,7 +2445,7 @@ var TaskLensPlugin = class extends import_obsidian13.Plugin {
     this.registerView(VIEW_TYPE_TIMELINE, (leaf) => new TimelineView(leaf, this));
     this.registerView(VIEW_TYPE_LIST, (leaf) => new TaskListView(leaf, this));
     this.registerView(VIEW_TYPE_STATS, (leaf) => new StatsView(leaf, this));
-    (0, import_obsidian13.addIcon)("tasklens-icon", TASKLENS_ICON);
+    (0, import_obsidian13.addIcon)(ICON_NAME, ICON_SVG);
     this.setupRibbonIcon();
     this.setupCommands();
     if (!this.settings.hasSeenWelcome) {
@@ -2446,8 +2459,8 @@ var TaskLensPlugin = class extends import_obsidian13.Plugin {
     });
   }
   setupRibbonIcon() {
-    const ribbonIconEl = this.addRibbonIcon("tasklens-icon", "Tasklens", (evt) => {
-      ribbonIconEl.removeClass("feature-highlight");
+    const ribbonIconEl = this.addRibbonIcon(ICON_NAME, "Tasklens", (evt) => {
+      ribbonIconEl.removeClass(CLASS_FEATURE_HIGHLIGHT);
       if (!this.settings.hasClickedRibbonIcon) {
         this.settings.hasClickedRibbonIcon = true;
         void this.saveSettings();
@@ -2477,7 +2490,7 @@ var TaskLensPlugin = class extends import_obsidian13.Plugin {
       menu.showAtMouseEvent(evt);
     });
     if (!this.settings.hasSeenWelcome || !this.settings.hasClickedRibbonIcon) {
-      ribbonIconEl.addClass("feature-highlight");
+      ribbonIconEl.addClass(CLASS_FEATURE_HIGHLIGHT);
     }
   }
   setupCommands() {
@@ -2513,7 +2526,7 @@ var TaskLensPlugin = class extends import_obsidian13.Plugin {
       this.app.workspace.getLeavesOfType(type).forEach((leaf) => {
         const tabContainer = leaf.view.containerEl.closest(".workspace-tabs");
         if (tabContainer) {
-          tabContainer.classList.toggle("tasklens-hide-tabs", this.isLayoutLocked);
+          tabContainer.classList.toggle(CLASS_HIDE_TABS, this.isLayoutLocked);
         }
       });
     });
@@ -2564,7 +2577,7 @@ var TaskLensPlugin = class extends import_obsidian13.Plugin {
     } else {
       const tabContainer = leaf.view.containerEl.closest(".workspace-tabs");
       if (tabContainer instanceof HTMLElement) {
-        tabContainer.classList.remove("tasklens-hide-tabs");
+        tabContainer.classList.remove(CLASS_HIDE_TABS);
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-    "version": "node version-bump.mjs && git add manifest.json versions.json"
+    "version": "node version-bump.mjs && git add manifest.json versions.json",
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "Selim",
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.4",
+    "@eslint/json": "^1.1.0",
     "@types/node": "^16.11.6",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
@@ -22,6 +24,7 @@
     "obsidian": "^1.7.2",
     "tslib": "2.4.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.56.1"
+    "typescript-eslint": "^8.56.1",
+    "vitest": "^4.1.0"
   }
 }

--- a/src/services/TaskManager.test.ts
+++ b/src/services/TaskManager.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { TaskManager } from './TaskManager';
+
+describe('TaskManager', () => {
+    describe('formatDisplayDate', () => {
+        it('should format normal dates correctly', () => {
+            const date = new Date(2024, 4, 15); // May 15, 2024
+            expect(TaskManager.formatDisplayDate(date)).toBe('15-05-2024');
+        });
+
+        it('should pad single digit days and months with zero', () => {
+            const date = new Date(2024, 0, 5); // Jan 5, 2024
+            expect(TaskManager.formatDisplayDate(date)).toBe('05-01-2024');
+        });
+
+        it('should handle end of year and month dates', () => {
+            const date = new Date(2024, 11, 31); // Dec 31, 2024
+            expect(TaskManager.formatDisplayDate(date)).toBe('31-12-2024');
+        });
+
+        it('should handle leap year dates', () => {
+            const date = new Date(2024, 1, 29); // Feb 29, 2024
+            expect(TaskManager.formatDisplayDate(date)).toBe('29-02-2024');
+        });
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    alias: {
+      'obsidian': '/__mocks__/obsidian.ts'
+    }
+  }
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `TaskManager.formatDisplayDate` function lacked unit tests, which are important for ensuring correct date formatting and zero-padding logic.

📊 **Coverage:** What scenarios are now tested
- Normal dates (e.g., `15-05-2024`)
- Dates requiring zero-padding for single-digit days and months (e.g., `05-01-2024`)
- End-of-year/month boundaries (e.g., `31-12-2024`)
- Leap year dates (e.g., `29-02-2024`)

✨ **Result:** The improvement in test coverage
The static date formatting function is now fully covered by tests, catching potential regressions. Additionally, the project is now set up with Vitest and a basic mock of the `obsidian` API, paving the way for further testing.

---
*PR created automatically by Jules for task [11695769425507796577](https://jules.google.com/task/11695769425507796577) started by @nightaqua*